### PR TITLE
(#3) disable installing on non-windows

### DIFF
--- a/Source/Cake.Chocolatey.Module.Tests/Cake.Chocolatey.Module.Tests.csproj
+++ b/Source/Cake.Chocolatey.Module.Tests/Cake.Chocolatey.Module.Tests.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="Cake.Testing" Version="$(CakeVersion)">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Cake.Testing.Xunit" Version="$(CakeVersion)">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Source/Cake.Chocolatey.Module.Tests/ChocolateyPackageInstallerTests.cs
+++ b/Source/Cake.Chocolatey.Module.Tests/ChocolateyPackageInstallerTests.cs
@@ -1,13 +1,18 @@
-﻿using Cake.Core.Diagnostics;
-using Cake.Core.IO;
-using Cake.Core.Packaging;
+﻿using Cake.Core.Packaging;
 using NSubstitute;
 using System;
-using System.Collections.Generic;
+
+using Cake.Testing.Xunit;
+
 using Xunit;
 
 namespace Cake.Chocolatey.Module.Tests
 {
+    /*
+     * Most of the WindowsFactAttributes should be "normal" FactAttributes
+     * once https://github.com/cake-build/cake/issues/4322 is resolved.
+     */
+
     /// <summary>
     /// ChocolateyPackageInstaller unit tests
     /// </summary>
@@ -15,11 +20,11 @@ namespace Cake.Chocolatey.Module.Tests
     {
         public sealed class TheConstructor
         {
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Environment_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Environment = null;
 
                 // When
@@ -30,11 +35,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.Equal("environment", ((ArgumentNullException)result).ParamName);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Process_Runner_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.ProcessRunner = null;
 
                 // When
@@ -45,11 +50,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.Equal("processRunner", ((ArgumentNullException)result).ParamName);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Content_Resolver_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.ContentResolver = null;
 
                 // When
@@ -60,11 +65,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.Equal("contentResolver", ((ArgumentNullException)result).ParamName);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Log_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Log = null;
 
                 // When
@@ -80,11 +85,11 @@ namespace Cake.Chocolatey.Module.Tests
         {
             private string CHOCOLATEY_CONFIGKEY = "Chocolatey_Source";
 
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_URI_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = null;
 
                 // When
@@ -95,11 +100,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.Equal("package", ((ArgumentNullException)result).ParamName);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Be_Able_To_Install_If_Scheme_Is_Correct()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = new PackageReference("choco:?package=windristat");
 
                 // When
@@ -109,11 +114,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.True(result);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Not_Be_Able_To_Install_If_Scheme_Is_Incorrect()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = new PackageReference("homebrew:?package=windirstat");
 
                 // When
@@ -123,10 +128,10 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.False(result);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Ignore_Custom_Source_If_AbsoluteUri_Is_Used()
             {
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = new PackageReference("choco:http://absolute/?package=windirstat");
 
                 // When
@@ -137,10 +142,10 @@ namespace Cake.Chocolatey.Module.Tests
                 fixture.Config.DidNotReceive().GetValue(CHOCOLATEY_CONFIGKEY);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Use_Custom_Source_If_RelativeUri_Is_Used()
             {
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = new PackageReference("choco:?package=windirstat");
 
                 // When
@@ -154,11 +159,11 @@ namespace Cake.Chocolatey.Module.Tests
 
         public sealed class TheInstallMethod
         {
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Uri_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.Package = null;
 
                 // When
@@ -169,11 +174,11 @@ namespace Cake.Chocolatey.Module.Tests
                 Assert.Equal("package", ((ArgumentNullException)result).ParamName);
             }
 
-            [Fact]
+            [WindowsFact]
             public void Should_Throw_If_Install_Path_Is_Null()
             {
                 // Given
-                var fixture = new ChocolateyPackageInstallerFixture();
+                var fixture = ChocolateyPackageInstallerFixture.Windows;
                 fixture.InstallPath = null;
 
                 // When
@@ -182,6 +187,19 @@ namespace Cake.Chocolatey.Module.Tests
                 // Then
                 Assert.IsType<ArgumentNullException>(result);
                 Assert.Equal("path", ((ArgumentNullException)result).ParamName);
+            }
+
+            [Fact]
+            public void On_Non_Windows_Install_Does_Not_Fail()
+            {
+                var fixture = ChocolateyPackageInstallerFixture.Unix;
+                fixture.Package = new PackageReference("choco:?package=windirstat");
+
+                // When
+                var result = fixture.Install();
+
+                // Then
+                Assert.Single(result);
             }
         }
     }


### PR DESCRIPTION
and instead issue a warning.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This changes leaves everything untouched for a Windows-install, however, on non-Windows systems it does **not** try to run `choco` and instead issues a warning that the required software needs to be installed manually.

![image](https://github.com/user-attachments/assets/35bbc9f8-122b-48d0-be95-40ccde93b558)

When a the required executable exists on non-Windows systesm, it is executes, as expected.

```bash
cat << 'EOF' > hello.exe
#!/bin/sh
echo "this is a faked hello.exe"
EOF

chmod +x hello.exe
```

![image](https://github.com/user-attachments/assets/a6f05899-074d-4eb8-b0ec-6df70093fd87)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #3 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#3 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
